### PR TITLE
Fix SDK error handler to comply with Kazoo error format

### DIFF
--- a/lib/Kazoo/HttpClient/Listener/ErrorListener.php
+++ b/lib/Kazoo/HttpClient/Listener/ErrorListener.php
@@ -70,29 +70,10 @@ class ErrorListener
 
     private function collectValidationErrors($content) {
         $errors = array();
-        foreach ($content['errors'] as $error) {
-            switch ($error['code']) {
-            case 'missing':
-                $errors[] = sprintf('The %s %s does not exist, for resource "%s"', $error['field'], $error['value'], $error['resource']);
-                break;
-
-            case 'missing_field':
-                $errors[] = sprintf('Field "%s" is missing, for resource "%s"', $error['field'], $error['resource']);
-                break;
-
-            case 'invalid':
-                $errors[] = sprintf('Field "%s" is invalid, for resource "%s"', $error['field'], $error['resource']);
-                break;
-
-            case 'already_exists':
-                $errors[] = sprintf('Field "%s" already exists, for resource "%s"', $error['field'], $error['resource']);
-                break;
-
-            default:
-                $errors[] = $error['message'];
-                break;
-
-            }
+        if(isset($content['data'][$content['message']])) {
+            $errors[] = $content['data'][$content['message']];
+        } else {
+            $errors[] = $content['message'];
         }
 
         throw new ValidationFailedException('Validation Failed: ' . implode(', ', $errors), 422);


### PR DESCRIPTION
SDK is throwing errors when Kazoo is returning an error message because the SDK is expecting an error format that Kazoo isn't sending. The Kazoo error format is clearly defined here: https://2600hz.atlassian.net/wiki/display/APIs/API+Introduction

This change updates how the SDK is getting an error message to match what Kazoo is actually sending.
